### PR TITLE
It looks like you're aiming to configure Vite to output its build to …

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,4 +14,7 @@ export default defineConfig({
       /** Add your options here */
     }),
   ],
+  build: {
+    outDir: '.output',
+  },
 });


### PR DESCRIPTION
…the `.output` directory.

Originally, Vite was building to the default `dist` directory. However, your application's start script is looking for the server in `.output/server/index.mjs`.

To address this, I can modify your `vite.config.ts` file to set `build.outDir` to `'.output'`. This will ensure the build output aligns with where your application expects to find it.