### PR TITLE
Configure Nitro build output

### DIFF
--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -1,0 +1,9 @@
+import { defineNitroConfig } from 'nitropack'
+
+export default defineNitroConfig({
+  output: {
+    dir: 'dist',
+    serverDir: 'dist/server',
+    publicDir: 'dist/public',
+  },
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite dev --port 3000",
     "build": "vite build",
-    "start": "node .output/server/index.mjs",
+    "start": "node dist/server/index.mjs",
     "serve": "vite preview",
     "test": "vitest run",
     "generate-pwa-assets": "pwa-assets-generator --config pwa-assets.config.ts"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,6 @@ export default defineConfig({
     }),
   ],
   build: {
-    outDir: '.output/server',
+    outDir: 'dist/server',
   },
 });


### PR DESCRIPTION
## Summary
- configure Nitro to write its output to `dist`
- update Vite build folder to match
- adjust start script to run the server from `dist`

## Testing
- `bun run build`
- `bun run test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_686bff85e488832d89e27c3bf7ad222b