### PR TITLE
Add external Bible link button

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -14,6 +14,9 @@ const enResources = {
     oldTestament: 'Old Testament',
     newTestament: 'New Testament',
 
+    // External links
+    openInBible: 'Open in Bible',
+
     // Audio player
     failedToLoadAudio: 'Failed to load audio file:',
     unknownError: 'Unknown error',
@@ -41,6 +44,9 @@ const ruResources = {
     selectChapter: 'Выберите главу',
     oldTestament: 'Ветхий Завет',
     newTestament: 'Новый Завет',
+
+    // External links
+    openInBible: 'Открыть в Библии',
 
     // Audio player
     failedToLoadAudio: 'Не удалось загрузить аудиофайл:',

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,6 +10,8 @@ import { Separator } from '@/components/ui/separator';
 import { useTranslation } from 'react-i18next';
 import { LocaleSwitcher } from '@/components/ui/locale-switcher';
 import { useSyncLanguage } from '@/lib/i18n';
+import { Button } from '@/components/ui/button';
+import { ExternalLinkIcon } from 'lucide-react';
 
 export const Route = createFileRoute('/')({
   component: () => <BibleNavigator />,
@@ -40,9 +42,26 @@ function BibleNavigator() {
         </div>
 
         <div className='grid gap-y-2'>
-          <div className='flex items-center justify-between gap-2'>
+          <div className='flex flex-wrap items-center justify-between gap-2'>
             <BibleInfo book={selection.book} />
-            <HistoryDialog />
+            <div className='flex items-center gap-2'>
+              <Button
+                asChild
+                variant='outline'
+                size='sm'
+                aria-label={t('openInBible')}
+              >
+                <a
+                  href='https://www.perplexity.ai/search/bdce9948-7853-4133-83bd-14628c702827'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                >
+                  <ExternalLinkIcon className='h-4 w-4' />
+                  {t('openInBible')}
+                </a>
+              </Button>
+              <HistoryDialog />
+            </div>
           </div>
 
           <AudioSection


### PR DESCRIPTION
## Summary
- add an "Open in Bible" button that links to the provided resource
- extend the i18n resources with strings for the new button label

## Testing
- pnpm test *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0318ead90832d9191b52d8eca5682