### PR TITLE
Improve dark mode background styling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -125,6 +125,82 @@ code {
 }
 
 .dark {
+  --background: oklch(0.18 0.025 72);
+  --foreground: oklch(0.93 0.018 95);
+  --card: oklch(0.23 0.024 72);
+  --card-foreground: oklch(0.93 0.018 95);
+  --popover: oklch(0.23 0.024 72);
+  --popover-foreground: oklch(0.93 0.018 95);
+  --primary: oklch(0.76 0.1 108);
+  --primary-foreground: oklch(0.19 0.02 76);
+  --primary-border: oklch(0.63 0.092 108);
+  --secondary: oklch(0.3 0.03 74);
+  --secondary-foreground: oklch(0.93 0.018 95);
+  --muted: oklch(0.27 0.022 75);
+  --muted-foreground: oklch(0.74 0.02 90);
+  --accent: oklch(0.3 0.03 74);
+  --accent-foreground: oklch(0.93 0.018 95);
+  --destructive: oklch(0.67 0.2 27);
+  --destructive-foreground: oklch(0.94 0.02 15);
+  --destructive-border: oklch(0.55 0.2 27);
+  --border: oklch(0.36 0.02 75);
+  --input: oklch(0.31 0.022 75);
+  --ring: oklch(0.7 0.05 95);
+  --sidebar-foreground: oklch(0.93 0.018 95);
+  --sidebar: oklch(0.24 0.025 72);
+  --sidebar-primary: oklch(0.76 0.1 108);
+  --sidebar-primary-foreground: oklch(0.19 0.02 76);
+  --sidebar-accent: oklch(0.3 0.03 74);
+  --sidebar-accent-foreground: oklch(0.93 0.018 95);
+  --sidebar-border: oklch(0.36 0.02 75);
+  --sidebar-ring: oklch(0.7 0.05 95);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) {
+    color-scheme: dark;
+    --background: oklch(0.18 0.025 72);
+    --foreground: oklch(0.93 0.018 95);
+    --card: oklch(0.23 0.024 72);
+    --card-foreground: oklch(0.93 0.018 95);
+    --popover: oklch(0.23 0.024 72);
+    --popover-foreground: oklch(0.93 0.018 95);
+    --primary: oklch(0.76 0.1 108);
+    --primary-foreground: oklch(0.19 0.02 76);
+    --primary-border: oklch(0.63 0.092 108);
+    --secondary: oklch(0.3 0.03 74);
+    --secondary-foreground: oklch(0.93 0.018 95);
+    --muted: oklch(0.27 0.022 75);
+    --muted-foreground: oklch(0.74 0.02 90);
+    --accent: oklch(0.3 0.03 74);
+    --accent-foreground: oklch(0.93 0.018 95);
+    --destructive: oklch(0.67 0.2 27);
+    --destructive-foreground: oklch(0.94 0.02 15);
+    --destructive-border: oklch(0.55 0.2 27);
+    --border: oklch(0.36 0.02 75);
+    --input: oklch(0.31 0.022 75);
+    --ring: oklch(0.7 0.05 95);
+    --sidebar-foreground: oklch(0.93 0.018 95);
+    --sidebar: oklch(0.24 0.025 72);
+    --sidebar-primary: oklch(0.76 0.1 108);
+    --sidebar-primary-foreground: oklch(0.19 0.02 76);
+    --sidebar-accent: oklch(0.3 0.03 74);
+    --sidebar-accent-foreground: oklch(0.93 0.018 95);
+    --sidebar-border: oklch(0.36 0.02 75);
+    --sidebar-ring: oklch(0.7 0.05 95);
+  }
+
+  body {
+    background-image:
+      radial-gradient(circle at 20% -10%, oklch(0.35 0.05 95 / 0.25), transparent 38%),
+      radial-gradient(circle at 85% -20%, oklch(0.38 0.05 80 / 0.18), transparent 34%);
+    background-attachment: fixed;
+  }
+
+  .texture {
+    opacity: 0.08;
+    mix-blend-mode: screen;
+  }
 }
 
 @layer base {

--- a/src/styles.css
+++ b/src/styles.css
@@ -125,6 +125,7 @@ code {
 }
 
 .dark {
+  color-scheme: dark;
   --background: oklch(0.18 0.025 72);
   --foreground: oklch(0.93 0.018 95);
   --card: oklch(0.23 0.024 72);
@@ -154,6 +155,18 @@ code {
   --sidebar-accent-foreground: oklch(0.93 0.018 95);
   --sidebar-border: oklch(0.36 0.02 75);
   --sidebar-ring: oklch(0.7 0.05 95);
+}
+
+.dark body {
+  background-image:
+    radial-gradient(circle at 20% -10%, oklch(0.35 0.05 95 / 0.25), transparent 38%),
+    radial-gradient(circle at 85% -20%, oklch(0.38 0.05 80 / 0.18), transparent 34%);
+  background-attachment: fixed;
+}
+
+.dark .texture {
+  opacity: 0.08;
+  mix-blend-mode: screen;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -190,14 +203,14 @@ code {
     --sidebar-ring: oklch(0.7 0.05 95);
   }
 
-  body {
+  :root:not(.light) body {
     background-image:
       radial-gradient(circle at 20% -10%, oklch(0.35 0.05 95 / 0.25), transparent 38%),
       radial-gradient(circle at 85% -20%, oklch(0.38 0.05 80 / 0.18), transparent 34%);
     background-attachment: fixed;
   }
 
-  .texture {
+  :root:not(.light) .texture {
     opacity: 0.08;
     mix-blend-mode: screen;
   }


### PR DESCRIPTION
### Motivation
- Make the app look and read better in dark mode by providing a cohesive dark token set and subtle background depth. 
- Ensure users who rely on OS dark mode get the same improved visuals even if the `.dark` class is not applied.
- Reduce texture intensity and tweak blending so the background is supportive without distracting from content.

### Description
- Added a full dark theme token set inside `.dark` to tune `--background`, surface colors, borders, inputs, and sidebar tokens in `src/styles.css`.
- Added a `@media (prefers-color-scheme: dark)` fallback that applies the same tokens to `:root:not(.light)` and sets `color-scheme: dark` so OS-level dark mode is respected.
- Enhanced visual depth by adding subtle radial gradients on `body` for dark mode and setting `.texture` to `mix-blend-mode: screen` with reduced opacity.
- Kept existing light tokens intact and made the dark rules scoped so they only apply when appropriate.

### Testing
- Ran package install with `bun install`, which completed successfully.  
- Built the app with `bun run build`, which completed successfully and produced client and server bundles.  
- Started the dev server with `bun run dev` and verified the app served on `http://localhost:3000/`.  
- Captured an automated dark-mode screenshot via Playwright to visually validate the new background, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2224e2d7c832d84a15b9a9e234705)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only CSS changes, but broad token updates may cause unintended contrast/regression across components in dark mode and OS dark-mode fallback cases.
> 
> **Overview**
> Improves dark mode styling by introducing a full `.dark` token set (including `color-scheme: dark`) for surfaces, borders/inputs, and sidebar colors.
> 
> Adds a `prefers-color-scheme: dark` fallback that applies the same tokens to `:root:not(.light)` so OS-level dark mode is respected even without the `.dark` class.
> 
> Enhances dark-mode background depth with subtle fixed radial gradients on `body` and tones down the `.texture` overlay via lower opacity and `mix-blend-mode: screen`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfb9e0e72ec43bb1f6a2e514ef43be1eb0ce3652. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->