### PR TITLE
fix: restore macOS autoplay while preserving iOS playback workaround

### DIFF
--- a/src/components/ui/audio-player.tsx
+++ b/src/components/ui/audio-player.tsx
@@ -15,6 +15,10 @@ import { Gauge, Pause, Play, Volume2, VolumeX } from 'lucide-react';
 import { useAudioStore } from '@/store/audio-store';
 import { useMediaSession } from '@/hooks/useMediaSession';
 import { useAudioShortcuts } from '@/hooks/useAudioShortcuts';
+import {
+  needsRestrictedAutoplayWorkaround,
+  usesDesktopAutoplay,
+} from '@/lib/device-detection';
 import type { BibleBook } from '@/types/bible';
 
 interface AudioPlayerProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -54,6 +58,8 @@ export function AudioPlayer({
 }: AudioPlayerProps) {
   const audioRef = useRef<HTMLAudioElement>(null);
   const autoPlayTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const iosLoadingTriggeredRef = useRef(false);
+  const wasPlayingRef = useRef(false);
   const preloadedNextSrcRef = useRef<string | null>(null);
   const preloadAudioRef = useRef<HTMLAudioElement | null>(null);
   const preloadLinkRef = useRef<HTMLLinkElement | null>(null);
@@ -139,11 +145,58 @@ export function AudioPlayer({
     return ranges.join(', ');
   };
 
+  const attemptDesktopAutoplay = async (
+    audio: HTMLAudioElement,
+    eventName: string,
+  ) => {
+    if (!usesDesktopAutoplay()) return;
+
+    updateDebug({
+      autoplayAttempted: true,
+      lastEvent: `${eventName}-autoplay-attempt`,
+    });
+
+    try {
+      await audio.play();
+      setIsPlaying(true);
+      setError(null);
+      updateDebug({
+        autoplaySuccess: true,
+        loadingState: 'playing',
+        lastEvent: `${eventName}-autoplay-success`,
+      });
+    } catch (err) {
+      console.error('Desktop auto-play failed:', err);
+      updateDebug({
+        autoplayError:
+          err instanceof Error ? err.message : 'Unknown autoplay error',
+        autoplaySuccess: false,
+        lastEvent: `${eventName}-autoplay-failed`,
+      });
+    }
+  };
+
+  const scheduleDesktopAutoplay = (
+    audio: HTMLAudioElement,
+    eventName: string,
+    delayMs = 500,
+  ) => {
+    if (!usesDesktopAutoplay()) return;
+
+    if (autoPlayTimeoutRef.current) {
+      clearTimeout(autoPlayTimeoutRef.current);
+    }
+
+    autoPlayTimeoutRef.current = setTimeout(() => {
+      void attemptDesktopAutoplay(audio, eventName);
+    }, delayMs);
+  };
+
   // iOS-specific loading trigger
   const triggerIOSLoading = async (audio: HTMLAudioElement) => {
-    const isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent);
-    if (!isIOS) return false;
+    if (!needsRestrictedAutoplayWorkaround()) return false;
 
+    iosLoadingTriggeredRef.current = true;
     updateDebug({
       iosLoadingTriggered: true,
       loadingState: 'triggering-ios-loading',
@@ -180,6 +233,7 @@ export function AudioPlayer({
     try {
       await audioRef.current.play();
       setIsPlaying(true);
+      wasPlayingRef.current = true;
       setError(null);
       updateDebug({ autoplaySuccess: true, lastEvent: 'manual-play-success' });
     } catch (err) {
@@ -198,6 +252,7 @@ export function AudioPlayer({
     try {
       await audioRef.current.pause();
       setIsPlaying(false);
+      wasPlayingRef.current = false;
       updateDebug({ lastEvent: 'pause' });
     } catch (err) {
       console.error('Pause error:', err);
@@ -341,9 +396,11 @@ export function AudioPlayer({
       });
       updateAudioState('loadedmetadata');
 
-      // On iOS, trigger loading after metadata is loaded
-      const isIOS = /iPhone|iPad|iPod/.test(navigator.userAgent);
-      if (isIOS && !debugInfo.iosLoadingTriggered) {
+      // On iOS/iPadOS, trigger loading after metadata is loaded
+      if (
+        needsRestrictedAutoplayWorkaround() &&
+        !iosLoadingTriggeredRef.current
+      ) {
         // Wait a bit for iOS to settle, then trigger loading
         setTimeout(async () => {
           const loadingTriggered = await triggerIOSLoading(audio);
@@ -356,6 +413,7 @@ export function AudioPlayer({
                   try {
                     await audio.play();
                     setIsPlaying(true);
+                    wasPlayingRef.current = true;
                     updateDebug({
                       autoplayAttempted: true,
                       autoplaySuccess: true,
@@ -420,7 +478,7 @@ export function AudioPlayer({
       updateAudioState('canplay');
     };
 
-    // Auto-play when audio finishes loading
+    // Auto-play when audio finishes loading (desktop/macOS only — iOS uses its own path)
     const handleCanPlayThrough = () => {
       updateDebug({
         canPlayThrough: true,
@@ -429,39 +487,7 @@ export function AudioPlayer({
       });
       updateAudioState('canplaythrough');
 
-      // Clear any existing timeout
-      if (autoPlayTimeoutRef.current) {
-        clearTimeout(autoPlayTimeoutRef.current);
-      }
-
-      // Auto-play after 500ms delay
-      autoPlayTimeoutRef.current = setTimeout(async () => {
-        updateDebug({
-          autoplayAttempted: true,
-          lastEvent: 'autoplay-attempt',
-        });
-
-        try {
-          await audio.play();
-          setIsPlaying(true);
-          setError(null);
-          updateDebug({
-            autoplaySuccess: true,
-            loadingState: 'playing',
-            lastEvent: 'autoplay-success',
-          });
-        } catch (err) {
-          console.error('Auto-play failed:', err);
-          updateDebug({
-            autoplayError:
-              err instanceof Error ? err.message : 'Unknown autoplay error',
-            autoplaySuccess: false,
-            lastEvent: 'autoplay-failed',
-          });
-          // Don't set error here as it might be due to browser autoplay policy
-          // User can still click play manually
-        }
-      }, 500);
+      scheduleDesktopAutoplay(audio, 'canplaythrough');
     };
 
     // Add all event listeners
@@ -481,8 +507,8 @@ export function AudioPlayer({
     // Set initial playback speed from store
     audio.playbackRate = playbackSpeed;
 
-    // Preload metadata
-    audio.preload = 'metadata';
+    // iOS limits loading unless triggered; desktop needs fuller preload for autoplay
+    audio.preload = needsRestrictedAutoplayWorkaround() ? 'metadata' : 'auto';
 
     return () => {
       // Clear timeout on cleanup
@@ -507,8 +533,19 @@ export function AudioPlayer({
 
   // Reset current time and debug info when src changes
   useEffect(() => {
+    const audio = audioRef.current;
+    const shouldContinuePlayback = wasPlayingRef.current;
+
     setCurrentTime(0);
     clearNextTrackPreload();
+
+    if (autoPlayTimeoutRef.current) {
+      clearTimeout(autoPlayTimeoutRef.current);
+      autoPlayTimeoutRef.current = null;
+    }
+
+    iosLoadingTriggeredRef.current = false;
+
     updateDebug({
       loadingState: 'loading-new-src',
       autoplayAttempted: false,
@@ -519,6 +556,35 @@ export function AudioPlayer({
       lastEvent: 'src-changed',
       iosLoadingTriggered: false,
     });
+
+    // Continue playback across chapter changes on desktop/macOS
+    if (audio && usesDesktopAutoplay() && shouldContinuePlayback) {
+      let onCanPlayThrough: (() => void) | undefined;
+
+      const tryContinuePlayback = () => {
+        if (audio.readyState >= 4) {
+          scheduleDesktopAutoplay(audio, 'chapter-change', 100);
+          return;
+        }
+
+        onCanPlayThrough = () => {
+          if (onCanPlayThrough) {
+            audio.removeEventListener('canplaythrough', onCanPlayThrough);
+          }
+          scheduleDesktopAutoplay(audio, 'chapter-change', 100);
+        };
+
+        audio.addEventListener('canplaythrough', onCanPlayThrough);
+      };
+
+      tryContinuePlayback();
+
+      return () => {
+        if (onCanPlayThrough) {
+          audio.removeEventListener('canplaythrough', onCanPlayThrough);
+        }
+      };
+    }
   }, [src]);
 
   useEffect(() => {

--- a/src/lib/device-detection.test.ts
+++ b/src/lib/device-detection.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isIOSDevice,
+  isMacOSDesktop,
+  needsRestrictedAutoplayWorkaround,
+  usesDesktopAutoplay,
+} from './device-detection';
+
+type NavigatorOverrides = {
+  userAgent: string;
+  maxTouchPoints?: number;
+};
+
+function withNavigator(
+  overrides: NavigatorOverrides,
+  run: () => void,
+): void {
+  const originalNavigator = globalThis.navigator;
+
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      ...originalNavigator,
+      userAgent: overrides.userAgent,
+      maxTouchPoints: overrides.maxTouchPoints ?? 0,
+    },
+  });
+
+  try {
+    run();
+  } finally {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    });
+  }
+}
+
+describe('device detection', () => {
+  it('detects iPhone user agents as iOS', () => {
+    withNavigator(
+      {
+        userAgent:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+      },
+      () => {
+        expect(isIOSDevice()).toBe(true);
+        expect(isMacOSDesktop()).toBe(false);
+        expect(needsRestrictedAutoplayWorkaround()).toBe(true);
+        expect(usesDesktopAutoplay()).toBe(false);
+      },
+    );
+  });
+
+  it('detects iPadOS desktop mode via touch points', () => {
+    withNavigator(
+      {
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15',
+        maxTouchPoints: 5,
+      },
+      () => {
+        expect(isIOSDevice()).toBe(true);
+        expect(isMacOSDesktop()).toBe(false);
+        expect(needsRestrictedAutoplayWorkaround()).toBe(true);
+      },
+    );
+  });
+
+  it('detects macOS desktop Safari as desktop autoplay', () => {
+    withNavigator(
+      {
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+        maxTouchPoints: 0,
+      },
+      () => {
+        expect(isIOSDevice()).toBe(false);
+        expect(isMacOSDesktop()).toBe(true);
+        expect(needsRestrictedAutoplayWorkaround()).toBe(false);
+        expect(usesDesktopAutoplay()).toBe(true);
+      },
+    );
+  });
+});

--- a/src/lib/device-detection.ts
+++ b/src/lib/device-detection.ts
@@ -1,0 +1,50 @@
+const IOS_USER_AGENT_PATTERN = /iPhone|iPod|iPad/;
+
+/**
+ * Detects iOS devices, including iPadOS Safari in desktop mode where the
+ * user agent reports as Macintosh but touch points are available.
+ */
+export function isIOSDevice(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  if (IOS_USER_AGENT_PATTERN.test(navigator.userAgent)) {
+    return true;
+  }
+
+  return navigator.maxTouchPoints > 1 && /Mac/.test(navigator.userAgent);
+}
+
+/**
+ * Detects macOS desktop browsers (Safari, Chrome, etc.) that are not iOS/iPadOS.
+ */
+export function isMacOSDesktop(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+
+  if (isIOSDevice()) {
+    return false;
+  }
+
+  return /Mac/.test(navigator.userAgent);
+}
+
+/**
+ * iOS and iPadOS need the play/pause loading workaround before autoplay.
+ * Desktop macOS uses the standard canplaythrough autoplay path instead.
+ *
+ * Viewport size is intentionally not used here: macOS typically has a large
+ * viewport and must not be routed through the iOS workaround.
+ */
+export function needsRestrictedAutoplayWorkaround(): boolean {
+  return isIOSDevice();
+}
+
+/**
+ * Desktop browsers (including macOS) that can use canplaythrough autoplay.
+ */
+export function usesDesktopAutoplay(): boolean {
+  return !needsRestrictedAutoplayWorkaround();
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Autoplay was working on iOS but not on macOS because platform detection was routing both paths incorrectly. This PR separates iOS/iPadOS from macOS desktop using actual device detection instead of viewport size, so each platform gets the autoplay strategy it needs.

## Changes

- **New `device-detection` helper** — reliably identifies iOS/iPadOS (including iPadOS desktop mode) vs macOS desktop
- **iOS path unchanged** — keeps the existing play/pause loading workaround that enables seamless chapter transitions on iOS
- **macOS/desktop path restored** — uses `canplaythrough` autoplay with `preload="auto"` for reliable buffering
- **Chapter continuity on macOS** — when a chapter ends while playing, the next chapter auto-resumes on desktop
- **Bug fixes** — clears stale autoplay timeouts on `src` change and uses a ref for `iosLoadingTriggered` to avoid stale closure issues

## Why viewport size was not used

macOS typically has a large viewport, while iOS has a small one. Using viewport alone to choose the autoplay path can flip the behavior: macOS gets the iOS workaround (which then bails out on user-agent check), while iOS gets the desktop path. Device detection avoids this mismatch.

## Testing

- Added unit tests for `isIOSDevice`, `isMacOSDesktop`, and autoplay routing helpers
- Existing audio helper tests still pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f3794fe-402d-40a6-b8c5-e7dfceab3a55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f3794fe-402d-40a6-b8c5-e7dfceab3a55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

